### PR TITLE
Feat: Add Stormlight Reclamation query box

### DIFF
--- a/src/macros/surges/common/stormlight-reclamation.js
+++ b/src/macros/surges/common/stormlight-reclamation.js
@@ -1,9 +1,16 @@
 
-export function stormlightReclamation(item, actor) {
+export async function stormlightReclamation(item, actor) {
 	//create popup to ask "how much stormlight do you reclaim"
-	// for now we'll just make a var that's set to 1;
-	var value = 1;
-	var newValue = actor.system.resources.inv.value + value;
-	if (newValue > actor.system.resources.inv.max.value){ newValue = actor.system.resources.inv.max.value};
-	actor.update({ 'system.resources.inv.value': newValue });
+	await foundry.applications.api.DialogV2.prompt({ //In foundry version 13 potentially replace with .input for cleaner macro?
+    	window: { title: "How much stormlight do you reclaim?" },
+		content: '<input name="value" type="number" min="1" max="99" step="1" autofocus>',
+    	ok: {
+	      	label: "Submit",
+      		callback: (event, button, dialog) => {
+				var newValue = actor.system.resources.inv.value + button.form.elements.value.valueAsNumber;
+				if (newValue > actor.system.resources.inv.max.value){ newValue = actor.system.resources.inv.max.value};
+				actor.update({ 'system.resources.inv.value': newValue });
+			}
+    	}
+	});
 }


### PR DESCRIPTION
Allows custom stormlight reclamation values instead of defaulting to 1