### PR TITLE
Feat: Reorganize Item Typing

### DIFF
--- a/src/packs/CAAActions/surges/illumination/dismiss-complex-illusion.json
+++ b/src/packs/CAAActions/surges/illumination/dismiss-complex-illusion.json
@@ -1,10 +1,10 @@
 {
     "name": "Dismiss Complex Illusion",
-    "type": "action",
+    "type": "power",
     "img": "icons/magic/light/hand-sparks-glow-yellow.webp",
     "system": {
         "id": "<id>",
-        "type": "basic",
+        "type": "surge",
         "description": {
             "value": "<p>Dismiss your complex illusion</p>",
             "chat": "",

--- a/src/packs/CAAActions/surges/illumination/dismiss-disguise.json
+++ b/src/packs/CAAActions/surges/illumination/dismiss-disguise.json
@@ -1,10 +1,10 @@
 {
     "name": "Dismiss Disguise",
-    "type": "action",
+    "type": "power",
     "img": "icons/magic/unholy/silhouette-robe-evil-power.webp",
     "system": {
         "id": "<id>",
-        "type": "basic",
+        "type": "surge",
         "description": {
             "value": "<p>Dismisses your own Illusion disguise</p>",
             "chat": "",

--- a/src/packs/CAAActions/surges/progression/cancel-character-regrowth.json
+++ b/src/packs/CAAActions/surges/progression/cancel-character-regrowth.json
@@ -1,9 +1,9 @@
 {
-    "type": "equipment",
+    "type": "power",
     "name": "Cancel Character Regrowth",
     "img": "icons/magic/life/cross-beam-green.webp",
     "system": {
-        "type": "basic",
+        "type": "surge",
         "description": {
             "value": "<p>Cancels the continous regrowth infusion</p>",
             "chat": "",

--- a/src/packs/CAAActions/surges/progression/cancel-regrowth-infusion.json
+++ b/src/packs/CAAActions/surges/progression/cancel-regrowth-infusion.json
@@ -1,9 +1,9 @@
 {
-    "type": "equipment",
+    "type": "power",
     "name": "Cancel Regrowth Infusion",
     "img": "icons/magic/life/cross-beam-green.webp",
     "system": {
-        "type": "basic",
+        "type": "surge",
         "description": {
             "value": "<p>Cancels the continous regrowth infusion</p>",
             "chat": "",


### PR DESCRIPTION
Surge cancel toggles now appear in the surge section of the action tab instead of under equipment